### PR TITLE
Update alt text event statuses

### DIFF
--- a/workshop-resources/alt-text/README.md
+++ b/workshop-resources/alt-text/README.md
@@ -23,15 +23,16 @@ Listed from oldest to newest
 | 2021 | scikit-learn (with [PyLadies South Florida](https://www.meetup.com/PyLadies-SoFlo/)) | [isabela-pf/scikit-learn #1](https://github.com/isabela-pf/scikit-learn/pull/1) | [scikit-learn/scikit-learn #21354](https://github.com/scikit-learn/scikit-learn/pull/21354) | Open | [Event recording](https://www.youtube.com/watch?v=dDpimPYOKuc) |
 | 2021 | Quansight Labs Blog | [isabela-pf/quansight-labs-site #2](https://github.com/isabela-pf/quansight-labs-site/pull/2) | [Quansight-Labs/quansight-labs-site #264](https://github.com/Quansight-Labs/quansight-labs-site/pull/264) | Merged |  |
 | 2021 | Dask | [scharlottej13/dask #1](https://github.com/scharlottej13/dask/pull/1) | [dask/dask #8456](https://github.com/dask/dask/pull/8456) | Merged |  |
-| 2022 | Project Jupyter | [isabela-pf/jupyter #1](https://github.com/isabela-pf/jupyter/pull/1) | [jupyter/jupyter #607](https://github.com/jupyter/jupyter/pull/607) | Open | [Event recording](https://youtu.be/KMWGClxcJGc) |
+| 2022 | Project Jupyter | [isabela-pf/jupyter #1](https://github.com/isabela-pf/jupyter/pull/1) | [jupyter/jupyter #607](https://github.com/jupyter/jupyter/pull/607) | Merged | [Event recording](https://youtu.be/KMWGClxcJGc) |
 | 2022 | Jupyter.org | [isabela-pf/jupyter.github.io #1](https://github.com/isabela-pf/jupyter.github.io/pull/1) | [jupyter/jupyter.github.io #680](https://github.com/jupyter/jupyter.github.io/pull/680) | Merged | [Event series blog post](https://blog.jupyter.org/jupyter-accessibility-workshops-wrap-up-8649dfe5f89) |
 | 2022 | napari | [isabela-pf/napari #2](https://github.com/isabela-pf/napari/pull/2) | [napari/napari #4375](https://github.com/napari/napari/pull/4375) | Merged |  |
 | 2022 | Scientific Python Blog | [MarsBarLee/blog.scientific-python.org #1](https://github.com/MarsBarLee/blog.scientific-python.org/pull/1) | [scientific-python/blog.scientific-python.org #71](https://github.com/scientific-python/blog.scientific-python.org/pull/71) | Merged | [Blog post](https://blog.scientific-python.org/posts/scientific-python/alt-text-workshop-summary/); [Event recording](https://youtu.be/Zn-zyU2lS0k) |
 | 2022 | Scientific Python Blog (with [RSE Asia](https://rse-asia.github.io/RSE_Asia/)) | [isabela-pf/blog.scientific-python.org #2](https://github.com/isabela-pf/blog.scientific-python.org/pull/2) | [scientific-python/blog.scientific-python.org #88](https://github.com/scientific-python/blog.scientific-python.org/pull/88) | Merged |  |
-| 2022 | Bokeh (with Quansight Labs - SciPy 2022) | [bokeh/bokeh #12211](https://github.com/bokeh/bokeh/pull/12211) |  | Working | [Blog post](https://labs.quansight.org/blog/alt-text-scipy-2022) for all Quansight Labs - SciPy 2022 events |
+| 2022 | Bokeh (with Quansight Labs - SciPy 2022) | [bokeh/bokeh #12211](https://github.com/bokeh/bokeh/pull/12211) |  | Merged | [Blog post](https://labs.quansight.org/blog/alt-text-scipy-2022) for all Quansight Labs - SciPy 2022 events |
 | 2022 | Dask (with Quansight Labs - SciPy 2022) | [pavithraes/dask #1](https://github.com/pavithraes/dask/pull/1) |  | Working |  |
-| 2022 | JupyterLab (with Quansight Labs - SciPy 2022) | [Quansight-Labs/jupyterlab #1](https://github.com/Quansight-Labs/jupyterlab/pull/1) |  | Working |  |
-| 2022 | SciPy (with Quansight Labs - SciPy 2022) | [scipy/scipy #16546](https://github.com/scipy/scipy/pull/16546) |  | Working |  |
+| 2022 | JupyterLab (with Quansight Labs - SciPy 2022) | [Quansight-Labs/jupyterlab #1](https://github.com/Quansight-Labs/jupyterlab/pull/1) | [jupyterlab/jupyterlab #12879](https://github.com/jupyterlab/jupyterlab/pull/12879) | Merged |  |
+| 2022 | SciPy (with Quansight Labs - SciPy 2022) | [scipy/scipy #16546](https://github.com/scipy/scipy/pull/16546) |  | Merged |  |
+| 2022 | napari | [isabela-pf/napari #5](https://github.com/isabela-pf/napari/pull/5) | [napari/docs #12](https://github.com/napari/docs/pull/12) (thanks to [@Carreau](https://github.com/Carreau) for porting our work!) | Merged |  |
 |  |  |  |  |  |  |
 
 ## Roll the credits


### PR DESCRIPTION
Just what it says on the tin. On `workshop-resources/alt-text/README.md` this PR:
- Adds the last alt text event of 2022 (with napari)
- Updates events that have had contributions merged since last update (Bokeh, JupyterLab, SciPy)

This should be up to date for the new year. I will leave it open for review for at least a week to double check before merging.