### PR TITLE
Update and correct keyboard event readme

### DIFF
--- a/workshop-resources/keyboard-navigation/README.md
+++ b/workshop-resources/keyboard-navigation/README.md
@@ -19,7 +19,7 @@ Listed from oldest to newest
 | Year | Project | Working location | Contributing location | Status | Other info | 
 |------|---------|------------|-----------------|--------|------------|
 | 2022 | Jupyter Notebook 7 | [isabela-pf/a11y-events #10](https://github.com/isabela-pf/a11y-events/pull/10) | [jupyter/notebook #6595](https://github.com/jupyter/notebook/issues/6595) | Contributed |  |
-| 2022 | jupyter/accessibility Documentation | [isabela-pf/a11y-events #10](https://github.com/isabela-pf/a11y-events/pull/11) | [jupyter/accessibility #114](https://github.com/jupyter/accessibility/issues/114) | Contributed |  |
+| 2022 | jupyter/accessibility Documentation | [isabela-pf/a11y-events #11](https://github.com/isabela-pf/a11y-events/pull/11) | [jupyter/accessibility #114](https://github.com/jupyter/accessibility/issues/114) | Contributed |  |
 
 ## Roll the credits
 

--- a/workshop-resources/keyboard-navigation/README.md
+++ b/workshop-resources/keyboard-navigation/README.md
@@ -20,6 +20,7 @@ Listed from oldest to newest
 |------|---------|------------|-----------------|--------|------------|
 | 2022 | Jupyter Notebook 7 | [isabela-pf/a11y-events #10](https://github.com/isabela-pf/a11y-events/pull/10) | [jupyter/notebook #6595](https://github.com/jupyter/notebook/issues/6595) | Contributed |  |
 | 2022 | jupyter/accessibility Documentation | [isabela-pf/a11y-events #11](https://github.com/isabela-pf/a11y-events/pull/11) | [jupyter/accessibility #114](https://github.com/jupyter/accessibility/issues/114) | Contributed |  |
+| 2023 | Pydata Sphinx Theme | [isabela-pf/a11y-events #14](https://github.com/isabela-pf/a11y-events/pull/14 |  |  |  |
 
 ## Roll the credits
 


### PR DESCRIPTION
On `workshop-resources/keyboard-navigation/README.md` this PR:
- Corrects a typo with the wrong issue number referenced for a past event
- Adds a run event to the table

I am leaving this open because I would like to update it with an upcoming event in the same PR. After the event, I will update and merge.